### PR TITLE
Upgrade to Kotlin 1.6

### DIFF
--- a/dgs-kotlin-co/build.gradle.kts
+++ b/dgs-kotlin-co/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("org.springframework.boot") version "2.5.6"
     id("io.spring.dependency-management") version "1.0.11.RELEASE"
     kotlin("plugin.spring") version "1.5.31"
-    kotlin("jvm") version "1.5.31"
+    kotlin("jvm") version "1.6.0"
     id("com.netflix.dgs.codegen") version "5.1.8" //https://plugins.gradle.org/plugin/com.netflix.dgs.codegen
 }
 

--- a/dgs-kotlin-co/build.gradle.kts
+++ b/dgs-kotlin-co/build.gradle.kts
@@ -4,8 +4,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id("org.springframework.boot") version "2.5.6"
     id("io.spring.dependency-management") version "1.0.11.RELEASE"
-    kotlin("plugin.spring") version "1.5.31"
+
     kotlin("jvm") version "1.6.0"
+    kotlin("plugin.spring") version "1.6.0"
     id("com.netflix.dgs.codegen") version "5.1.8" //https://plugins.gradle.org/plugin/com.netflix.dgs.codegen
 }
 

--- a/dgs-kotlin/build.gradle.kts
+++ b/dgs-kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("org.springframework.boot") version "2.5.6"
     id("io.spring.dependency-management") version "1.0.11.RELEASE"
     kotlin("jvm") version "1.5.31"
-    kotlin("plugin.spring") version "1.5.31"
+    kotlin("plugin.spring") version "1.6.0"
     id("com.netflix.dgs.codegen") version "5.1.8" //https://plugins.gradle.org/plugin/com.netflix.dgs.codegen
 }
 

--- a/dgs-kotlin/build.gradle.kts
+++ b/dgs-kotlin/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id("org.springframework.boot") version "2.5.6"
     id("io.spring.dependency-management") version "1.0.11.RELEASE"
-    kotlin("jvm") version "1.5.31"
+    kotlin("jvm") version "1.6.0"
     kotlin("plugin.spring") version "1.6.0"
     id("com.netflix.dgs.codegen") version "5.1.8" //https://plugins.gradle.org/plugin/com.netflix.dgs.codegen
 }

--- a/dgs-subscription-sse/build.gradle.kts
+++ b/dgs-subscription-sse/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 	id("org.springframework.boot") version "2.5.6"
 	id("io.spring.dependency-management") version "1.0.11.RELEASE"
 	kotlin("jvm") version "1.6.0"
-	kotlin("plugin.spring") version "1.5.31"
+	kotlin("plugin.spring") version "1.6.0"
 	id("com.netflix.dgs.codegen") version "5.1.8" //https://plugins.gradle.org/plugin/com.netflix.dgs.codegen
 }
 

--- a/dgs-subscription-sse/build.gradle.kts
+++ b/dgs-subscription-sse/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
 	id("org.springframework.boot") version "2.5.6"
 	id("io.spring.dependency-management") version "1.0.11.RELEASE"
-	kotlin("jvm") version "1.5.31"
+	kotlin("jvm") version "1.6.0"
 	kotlin("plugin.spring") version "1.5.31"
 	id("com.netflix.dgs.codegen") version "5.1.8" //https://plugins.gradle.org/plugin/com.netflix.dgs.codegen
 }

--- a/dgs-subscription-ws/build.gradle.kts
+++ b/dgs-subscription-ws/build.gradle.kts
@@ -4,8 +4,10 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
 	id("org.springframework.boot") version "2.5.6"
 	id("io.spring.dependency-management") version "1.0.11.RELEASE"
-	kotlin("plugin.spring") version "1.5.31"
+
 	kotlin("jvm") version "1.6.0"
+	kotlin("plugin.spring") version "1.6.0"
+
 	id("com.netflix.dgs.codegen") version "5.1.8" //https://plugins.gradle.org/plugin/com.netflix.dgs.codegen
 }
 

--- a/dgs-subscription-ws/build.gradle.kts
+++ b/dgs-subscription-ws/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 	id("org.springframework.boot") version "2.5.6"
 	id("io.spring.dependency-management") version "1.0.11.RELEASE"
 	kotlin("plugin.spring") version "1.5.31"
-	kotlin("jvm") version "1.5.31"
+	kotlin("jvm") version "1.6.0"
 	id("com.netflix.dgs.codegen") version "5.1.8" //https://plugins.gradle.org/plugin/com.netflix.dgs.codegen
 }
 


### PR DESCRIPTION
- chore(deps): bump jvm from 1.5.31 to 1.6.0 in /dgs-subscription-sse
- chore(deps): bump plugin.spring in /dgs-subscription-sse
- chore(deps): bump plugin.spring from 1.5.31 to 1.6.0 in /dgs-kotlin
- chore(deps): bump jvm from 1.5.31 to 1.6.0 in /dgs-kotlin
- chore(deps): bump jvm from 1.5.31 to 1.6.0 in /dgs-subscription-ws
- chore(deps): bump plugin.spring in /dgs-subscription-ws
- chore(deps): bump plugin.spring from 1.5.31 to 1.6.0 in /dgs-kotlin-co
- chore(deps): bump jvm from 1.5.31 to 1.6.0 in /dgs-kotlin-co
